### PR TITLE
Fix SSL errors on pip where python is on version 3.9.xxx and upwards on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible role: source-python
 ===========================
 
-This fork contains a fix for CentOS 7 to install python 3.9 
+![test](https://github.com/nmusatti/source-python/actions/workflows/test.yml/badge.svg)
 
 An Ansible role to download and install Python from source. Supported
 distributions are the currently maintained releases of the Red Hat family and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible role: source-python
 ===========================
 
-![test](https://github.com/nmusatti/source-python/actions/workflows/test.yml/badge.svg)
+This fork contains a fix for CentOS 7 to install python 3.9 
 
 An Ansible role to download and install Python from source. Supported
 distributions are the currently maintained releases of the Red Hat family and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,33 @@
   delay: 3
   when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] == '9'
 
+- name: Install dependencies (RedHat EL 8)
+  ansible.builtin.yum:
+    name:
+      - bzip2-devel
+      - gcc
+      - libdb
+      - libdb-devel
+      - libffi-devel
+      - libuuid-devel
+      - make
+      - ncurses
+      - ncurses-devel
+      - ncurses-libs
+      - openssl-devel
+      - readline-devel
+      - sqlite-devel
+      - tar
+      - tcl-devel
+      - tk-devel
+      - xz
+      - xz-devel
+    state: present
+  become: true
+  retries: 3
+  delay: 3
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] == '8'
+  
 - name: Install dependencies (Ubuntu)
   ansible.builtin.apt:
     name:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
       - ncurses-devel
       - ncurses-libs
       - openssl-devel
+      - openssl11-devel
       - readline-devel
       - sqlite-devel
       - tar
@@ -145,6 +146,13 @@
   ansible.builtin.stat:
     path: "{{ python_src_dir }}/Python-{{ python_release }}/config.log"
   register: configure_stat_result
+  
+- name: Use openssl11 to fix pip error
+  ansible.builtin.replace:
+    path: "{{ python_src_dir }}/Python-{{ python_release }}/configure"
+    regexp: 'PKG_CONFIG openssl '
+    replace: 'PKG_CONFIG openssl11 '
+    when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] != '9'
 
 - name: Run ./configure
   ansible.builtin.command: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,7 +152,7 @@
     path: "{{ python_src_dir }}/Python-{{ python_release }}/configure"
     regexp: 'PKG_CONFIG openssl '
     replace: 'PKG_CONFIG openssl11 '
-    when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] != '9'
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] != '9'
 
 - name: Run ./configure
   ansible.builtin.command: >


### PR DESCRIPTION
This PR used openssl11 to Fix SSL errors on pip where python is on version 3.9.xxx and upwards on CentOS 7